### PR TITLE
psr http-msg and http-factory version changed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "mockery/mockery": "^1.4",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0|^2.0"
+        "psr/http-factory": "^1.0"
     },
     "config" : {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "mockery/mockery": "^1.4",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0|^2.0"
     },
     "config" : {
         "platform": {

--- a/src/Template/Common/ComposerJsonTemplate.php
+++ b/src/Template/Common/ComposerJsonTemplate.php
@@ -30,9 +30,9 @@ class ComposerJsonTemplate
                     "nesbot/carbon": "^2.0",
                     "emulgeator/enum": "^1.0",
                     "emulgeator/array-to-class-mapper": "^0.1|^1.0",
-                    "psr/http-message": "^2.0",
+                    "psr/http-message": "^1.0|^2.0",
                     "psr/http-client": "^1.0",
-                    "psr/http-factory": "^1.1"
+                    "psr/http-factory": "^1.0"
                 },
                 "autoload": {
                   "psr-4": {

--- a/src/Template/Common/ComposerJsonTemplate.php
+++ b/src/Template/Common/ComposerJsonTemplate.php
@@ -30,9 +30,9 @@ class ComposerJsonTemplate
                     "nesbot/carbon": "^2.0",
                     "emulgeator/enum": "^1.0",
                     "emulgeator/array-to-class-mapper": "^0.1|^1.0",
-                    "psr/http-message": "^1.0",
+                    "psr/http-message": "^2.0",
                     "psr/http-client": "^1.0",
-                    "psr/http-factory": "^1.0"
+                    "psr/http-factory": "^1.1"
                 },
                 "autoload": {
                   "psr-4": {

--- a/test/Unit/Template/Common/ComposerJsonTemplateTest.php
+++ b/test/Unit/Template/Common/ComposerJsonTemplateTest.php
@@ -31,7 +31,7 @@ class ComposerJsonTemplateTest extends TemplateTestCaseAbstract
                     "emulgeator/array-to-class-mapper": "^0.1|^1.0",
                     "psr/http-message": "^1.0|^2.0",
                     "psr/http-client": "^1.0",
-                    "psr/http-factory": "^1.1"
+                    "psr/http-factory": "^1.0"
                 },
                 "autoload": {
                   "psr-4": {

--- a/test/Unit/Template/Common/ComposerJsonTemplateTest.php
+++ b/test/Unit/Template/Common/ComposerJsonTemplateTest.php
@@ -29,7 +29,7 @@ class ComposerJsonTemplateTest extends TemplateTestCaseAbstract
                     "nesbot/carbon": "^2.0",
                     "emulgeator/enum": "^1.0",
                     "emulgeator/array-to-class-mapper": "^0.1|^1.0",
-                    "psr/http-message": "^2.0",
+                    "psr/http-message": "^1.0|^2.0",
                     "psr/http-client": "^1.0",
                     "psr/http-factory": "^1.1"
                 },

--- a/test/Unit/Template/Common/ComposerJsonTemplateTest.php
+++ b/test/Unit/Template/Common/ComposerJsonTemplateTest.php
@@ -29,9 +29,9 @@ class ComposerJsonTemplateTest extends TemplateTestCaseAbstract
                     "nesbot/carbon": "^2.0",
                     "emulgeator/enum": "^1.0",
                     "emulgeator/array-to-class-mapper": "^0.1|^1.0",
-                    "psr/http-message": "^1.0",
+                    "psr/http-message": "^2.0",
                     "psr/http-client": "^1.0",
-                    "psr/http-factory": "^1.0"
+                    "psr/http-factory": "^1.1"
                 },
                 "autoload": {
                   "psr-4": {


### PR DESCRIPTION
The main difference between "psr/http-message" version 1.0 and 2.0 is that version 2.0 introduces declared return types for all methods in the interfaces, while version 1.0 did not. There are no breaking changes to behavior or the API, so upgrading from 1.0 to 2.0 is typically safe for most codebases, especially those already compatible with PHP 7.2 or newer.